### PR TITLE
feat: implement hourly DAB and fan-only override

### DIFF
--- a/tests/hourly-dab-tests.groovy
+++ b/tests/hourly-dab-tests.groovy
@@ -1,0 +1,37 @@
+package bot.flair
+
+import me.biocomp.hubitat_ci.util.CapturingLog
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
+import me.biocomp.hubitat_ci.app.HubitatAppSandbox
+import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Specification
+
+class HourlyDabTests extends Specification {
+
+  private static final File APP_FILE = new File('src/hubitat-flair-vents-app.groovy')
+  private static final List VALIDATION_FLAGS = [
+    Flags.DontValidateMetadata,
+    Flags.DontValidatePreferences,
+    Flags.DontValidateDefinition,
+    Flags.DontRestrictGroovy,
+    Flags.DontRequireParseMethodInDevice
+  ]
+
+  def "hourly rate history maintains rolling ten values"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    when:
+    (1..11).each { script.appendHourlyRate('room1', 'cooling', 0, it) }
+
+    then:
+    script.atomicState.hourlyRates.room1.cooling[0].size() == 10
+    script.getAverageHourlyRate('room1', 'cooling', 0) == 6.5
+  }
+}


### PR DESCRIPTION
## Summary
- track hourly efficiency rates with 10-day rolling history
- add fan-only option to force all vents open and pause DAB
- cover hourly rate helper with unit test

## Testing
- `gradle test` *(fails: Could not resolve all dependencies: Cannot find a Java installation matching languageVersion=11)*

------
https://chatgpt.com/codex/tasks/task_e_68a89f046cec8323a4c5f9d6336c9351