### PR TITLE
1 v1 Add hourly DAB chart page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.235] - 2025-08-22
+
+### Added
+- Chart page displaying hourly Dynamic Airflow Balancing (DAB) rates for each room
+
 ## [0.234] - 2025-07-06
 
 ### Fixed

--- a/tests/dab-chart-tests.groovy
+++ b/tests/dab-chart-tests.groovy
@@ -1,0 +1,46 @@
+package bot.flair
+
+import me.biocomp.hubitat_ci.util.CapturingLog
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
+import me.biocomp.hubitat_ci.app.HubitatAppSandbox
+import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Specification
+
+class DabChartTests extends Specification {
+
+  private static final File APP_FILE = new File('src/hubitat-flair-vents-app.groovy')
+  private static final List VALIDATION_FLAGS = [
+    Flags.DontValidateMetadata,
+    Flags.DontValidatePreferences,
+    Flags.DontValidateDefinition,
+    Flags.DontRestrictGroovy,
+    Flags.DontRequireParseMethodInDevice
+  ]
+
+  def "chart generation produces quickchart link"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { '1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr -> attr == 'room-name' ? 'Room1' : null }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> 'cooling' }
+    script.appendHourlyRate('1', 'cooling', 0, 1.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    html.contains('quickchart.io')
+  }
+}


### PR DESCRIPTION
## Summary
- add hourly DAB chart link and page using QuickChart
- expose chart generation helper and related test
- document new DAB chart feature

## Testing
- `gradle test` *(fails: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fa16f8448323ad20eb0a96c39de2