### PR TITLE
chore: bump version to 0.236

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -1,6 +1,6 @@
 /**
  *  Hubitat Flair Vents Integration
- *  Version 0.235
+ *  Version 0.236
  *
  *  Copyright 2024 Jaime Botero. All Rights Reserved
  *


### PR DESCRIPTION
## Summary
- update version to 0.236

## Testing
- `gradle test` *(fails: Could not find Java installation matching languageVersion=11)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6e7b156483239885ef5428e2698c