### PR TITLE
1 v1 add per-vent temperature setpoint

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2277,6 +2277,25 @@ def handleRoomPatch(resp, data) {
   traitExtract(data.device, resp.getJson(), 'active', 'room-active')
 }
 
+def patchRoomSetPoint(device, temp) {
+  def roomId = device.currentValue('room-id')
+  if (!roomId || temp == null) { return }
+  BigDecimal tempC = temp
+  if (getTemperatureScale() == 'F') {
+    tempC = convertFahrenheitToCentigrade(tempC)
+  }
+  log "Setting set-point to ${tempC}°C for '${device.currentValue('room-name')}'", 3
+  def uri = "${BASE_URL}/api/rooms/${roomId}"
+  def body = [ data: [ type: 'rooms', attributes: [ 'set-point-c': tempC ] ] ]
+  patchDataAsync(uri, 'handleRoomSetPointPatch', body, [device: device])
+}
+
+def handleRoomSetPointPatch(resp, data) {
+  decrementActiveRequests()
+  if (!isValidResponse(resp) || !data) { return }
+  traitExtract(data.device, resp.getJson(), 'set-point-c', 'room-set-point-c')
+}
+
 def thermostat1ChangeTemp(evt) {
   log "Thermostat changed temp to: ${evt.value}", 2
   def temp = settings?.thermostat1?.currentValue('temperature')

--- a/src/hubitat-flair-vents-driver.groovy
+++ b/src/hubitat-flair-vents-driver.groovy
@@ -76,6 +76,7 @@ metadata {
         attribute 'room-heating-rate', 'number'
 
         command 'setRoomActive', [[name: 'active*', type: 'ENUM', description: 'Set room active/away', constraints: ['true', 'false']]]
+        command 'setRoomSetPoint', [[name: 'temperature*', type: 'NUMBER', description: 'Set room temperature setpoint']]
     }
 
     preferences {
@@ -153,6 +154,11 @@ def getDeviceState(String attr) {
 def setRoomActive(isActive) {
   logDebug("setRoomActive: ${isActive}")
   parent.patchRoom(device, isActive)
+}
+
+def setRoomSetPoint(temp) {
+  logDebug("setRoomSetPoint: ${temp}")
+  parent.patchRoomSetPoint(device, temp)
 }
 
 def updateParentPollingInterval(Integer intervalMinutes) {


### PR DESCRIPTION
## Summary
- allow vents to expose a command for updating their room temperature setpoint
- route setpoint requests through the app to patch Flair room targets

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: Could not initialize SSL context)*

------
https://chatgpt.com/codex/tasks/task_e_68acd84eba188323a510f918cb25aa76