### PR TITLE
1.0 - isolate vent thermostat preference

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -243,7 +243,7 @@ def mainPage() {
         // Only show vents in DAB section, not pucks
         def vents = getChildDevices().findAll { it.hasAttribute('percent-open') }
         for (child in vents) {
-          input name: "thermostat${child.getId()}", type: 'capability.temperatureMeasurement', title: "Choose Thermostat for ${child.getLabel()} (Optional)", multiple: false, required: false
+          input name: "ventThermostat${child.getId()}", type: 'capability.temperatureMeasurement', title: "Choose Thermostat for ${child.getLabel()} (Optional)", multiple: false, required: false
         }
       }
 
@@ -401,7 +401,7 @@ private openAllVents(Map ventIdsByRoomId, int percentOpen) {
 private BigDecimal getRoomTemp(def vent) {
   def ventId = vent.getId()
   def roomName = vent.currentValue('room-name') ?: 'Unknown'
-  def tempDevice = settings."thermostat${ventId}"
+  def tempDevice = settings."ventThermostat${ventId}"
   
   if (tempDevice) {
     def temp = tempDevice.currentValue('temperature')
@@ -2764,7 +2764,7 @@ def getAttribsPerVentId(ventsByRoomId, String hvacMode) {
         
         // Log rooms with zero efficiency for debugging
         if (rate == 0) {
-          def tempSource = settings."thermostat${ventId}" ? "Puck ${settings."thermostat${ventId}".getLabel()}" : "Room API"
+          def tempSource = settings."ventThermostat${ventId}" ? "Puck ${settings."ventThermostat${ventId}".getLabel()}" : "Room API"
           log "Room '${roomName}' has zero ${hvacMode} efficiency rate, temp=${roomTemp}°C from ${tempSource}", 2
         }
         


### PR DESCRIPTION
## Summary
- ensure each vent uses its own `ventThermostat` preference to avoid colliding with the DAB thermostat setting
- update room-temperature lookups and logging to reference the new `ventThermostat` prefix

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test'. Cannot find a Java installation matching {languageVersion=11} )*

------
https://chatgpt.com/codex/tasks/task_e_68ace13b4ac48323917e0e59ff27fac7