### PR TITLE
1.0 Allow HVAC mode selection for DAB chart

### DIFF
--- a/tests/dab-chart-tests.groovy
+++ b/tests/dab-chart-tests.groovy
@@ -54,4 +54,72 @@ class DabChartTests extends Specification {
     def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
     config.data.datasets[0].data[0] == 1.0d
   }
+
+  def "chart falls back to last recorded mode when thermostat mode missing"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.appendHourlyRate('room-1', 'heating', 0, 2.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
+
+  def "chart merges heating and cooling data when both selected"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.metaClass.getSettings = { [chartHvacMode: 'both'] }
+    script.appendHourlyRate('room-1', 'cooling', 0, 1.0)
+    script.appendHourlyRate('room-1', 'heating', 0, 3.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
 }


### PR DESCRIPTION
## Summary
- let users pick which HVAC mode to visualize in the hourly DAB rates chart
- fall back to last recorded HVAC mode and merge datasets when viewing both modes
- cover mode selection and fallbacks with new chart tests

## Testing
- `gradle test` *(fails: missing Java toolchain; ca-certificates-java errors when attempting to install JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0662f8b0832394231ad8babfdbea