### PR TITLE
1.0 - trigger HVAC updates after vent refresh

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -368,9 +368,7 @@ def initialize() {
     }
   }
   
-  // Schedule periodic HVAC state detection based on duct temperatures
-  runEvery1Minute('updateHvacStateFromDuctTemps')
-  // Determine initial HVAC state and polling interval
+  // HVAC state will be updated after each vent refresh; compute initial state now
   updateHvacStateFromDuctTemps()
   // Schedule periodic cleanup of instance caches and pending requests
   runEvery5Minutes('cleanupPendingRequests')

--- a/src/hubitat-flair-vents-driver.groovy
+++ b/src/hubitat-flair-vents-driver.groovy
@@ -127,6 +127,8 @@ def refresh() {
 
 def settingsRefresh() {
   parent.getDeviceData(device)
+  // Invoke HVAC state update after refreshing vent data
+  parent.updateHvacStateFromDuctTemps()
 }
 
 void setLevel(level, duration=null) {


### PR DESCRIPTION
## Summary
- Remove minute-based HVAC state polling and rely on vent refresh events
- Trigger HVAC state update after each vent `settingsRefresh`

## Testing
- `gradle test` *(fails: trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68acaf1d5f7c8323b1b338a05d83154e