### PR TITLE
1.1 Fix hourly DAB chart lookup

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2466,7 +2466,8 @@ def evaluateRebalancingVents() {
 
 // Retrieve the average hourly efficiency rate for a room and HVAC mode
 def getAverageHourlyRate(String roomId, String hvacMode, Integer hour) {
-  def rates = atomicState?.hourlyRates?.get(roomId)?.get(hvacMode)?.get(hour)
+  def modeRates = atomicState?.hourlyRates?.get(roomId)?.get(hvacMode)
+  def rates = modeRates ? (modeRates["${hour}"] ?: modeRates[hour]) : null
   if (!rates || rates.size() == 0) { return 0.0 }
   BigDecimal sum = 0.0
   rates.each { sum += it as BigDecimal }
@@ -2478,13 +2479,15 @@ def appendHourlyRate(String roomId, String hvacMode, Integer hour, BigDecimal ra
   def hourlyRates = atomicState.hourlyRates ?: [:]
   def roomRates = hourlyRates[roomId] ?: [:]
   def modeRates = roomRates[hvacMode] ?: [:]
-  def list = modeRates[hour] ?: []
+  String hourKey = "${hour}"
+  def list = modeRates[hourKey] ?: []
   list << rate
   if (list.size() > 10) { list = list[-10..-1] }
-  modeRates[hour] = list
+  modeRates[hourKey] = list
   roomRates[hvacMode] = modeRates
   hourlyRates[roomId] = roomRates
   atomicState.hourlyRates = hourlyRates
+  atomicState.lastHvacMode = hvacMode
 }
 
 def appendDabActivityLog(String message) {
@@ -3342,6 +3345,8 @@ def dabActivityLogPage() {
 def dabChartPage() {
   dynamicPage(name: 'dabChartPage', title: '📊 Hourly DAB Rates', install: false, uninstall: false) {
     section {
+      input name: 'chartHvacMode', type: 'enum', title: 'HVAC Mode', required: false, submitOnChange: true,
+            options: [(COOLING): 'Cooling', (HEATING): 'Heating', 'both': 'Both']
       paragraph buildDabChart()
     }
     section {
@@ -3355,14 +3360,27 @@ String buildDabChart() {
   if (!vents || vents.size() == 0) {
     return '<p>No vent data available.</p>'
   }
-  String hvacMode = getThermostat1Mode() ?: COOLING
+  String hvacMode = settings?.chartHvacMode ?: getThermostat1Mode() ?: atomicState?.lastHvacMode
+  if (!hvacMode || hvacMode in ['auto', 'manual']) {
+    hvacMode = atomicState?.lastHvacMode
+  }
+  hvacMode = hvacMode ?: COOLING
   def labels = (0..23).collect { it.toString() }
   def datasets = vents.collect { vent ->
     // Use the Flair room ID if available to match stored hourly rate data
     def roomId = vent.currentValue('room-id') ?: vent.getId()
     def roomName = vent.currentValue('room-name') ?: vent.getLabel()
     def data = (0..23).collect { hr ->
-      getAverageHourlyRate(roomId, hvacMode, hr) ?: 0.0
+      if (hvacMode == 'both') {
+        def coolingMode = atomicState?.hourlyRates?.get(roomId)?.get(COOLING)
+        def heatingMode = atomicState?.hourlyRates?.get(roomId)?.get(HEATING)
+        def cooling = coolingMode ? (coolingMode["${hr}"] ?: coolingMode[hr]) : []
+        def heating = heatingMode ? (heatingMode["${hr}"] ?: heatingMode[hr]) : []
+        def combined = (cooling + heating).collect { it as BigDecimal }
+        combined ? cleanDecimalForJson(combined.sum() / combined.size()) : 0.0
+      } else {
+        getAverageHourlyRate(roomId, hvacMode, hr) ?: 0.0
+      }
     }
     [label: roomName, data: data]
   }

--- a/tests/dab-chart-tests.groovy
+++ b/tests/dab-chart-tests.groovy
@@ -54,4 +54,72 @@ class DabChartTests extends Specification {
     def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
     config.data.datasets[0].data[0] == 1.0d
   }
+
+  def "chart falls back to last recorded mode when thermostat mode missing"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.appendHourlyRate('room-1', 'heating', 0, 2.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
+
+  def "chart merges heating and cooling data when both selected"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.metaClass.getSettings = { [chartHvacMode: 'both'] }
+    script.appendHourlyRate('room-1', 'cooling', 0, 1.0)
+    script.appendHourlyRate('room-1', 'heating', 0, 3.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
 }

--- a/tests/hourly-dab-tests.groovy
+++ b/tests/hourly-dab-tests.groovy
@@ -31,7 +31,7 @@ class HourlyDabTests extends Specification {
     (1..11).each { script.appendHourlyRate('room1', 'cooling', 0, it) }
 
     then:
-    script.atomicState.hourlyRates.room1.cooling[0].size() == 10
+    script.atomicState.hourlyRates.room1.cooling['0'].size() == 10
     script.getAverageHourlyRate('room1', 'cooling', 0) == 6.5
   }
 }


### PR DESCRIPTION
## Summary
- normalize hourly DAB data keys to strings to ensure chart lookup succeeds
- handle combined cooling/heating dataset retrieval for "both" mode
- update tests for string-based hourly indexes

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching toolchain requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0662f8b0832394231ad8babfdbea