### PR TITLE
1 v1: fix DAB chart data rendering

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2485,6 +2485,7 @@ def appendHourlyRate(String roomId, String hvacMode, Integer hour, BigDecimal ra
   roomRates[hvacMode] = modeRates
   hourlyRates[roomId] = roomRates
   atomicState.hourlyRates = hourlyRates
+  atomicState.lastHvacMode = hvacMode
 }
 
 def appendDabActivityLog(String message) {
@@ -3342,6 +3343,8 @@ def dabActivityLogPage() {
 def dabChartPage() {
   dynamicPage(name: 'dabChartPage', title: '📊 Hourly DAB Rates', install: false, uninstall: false) {
     section {
+      input name: 'chartHvacMode', type: 'enum', title: 'HVAC Mode', required: false, submitOnChange: true,
+            options: [(COOLING): 'Cooling', (HEATING): 'Heating', 'both': 'Both']
       paragraph buildDabChart()
     }
     section {
@@ -3355,17 +3358,34 @@ String buildDabChart() {
   if (!vents || vents.size() == 0) {
     return '<p>No vent data available.</p>'
   }
-  String hvacMode = getThermostat1Mode() ?: COOLING
+  String hvacMode = settings?.chartHvacMode ?: getThermostat1Mode() ?: atomicState?.lastHvacMode
+  if (!hvacMode || hvacMode in ['auto', 'manual']) {
+    hvacMode = atomicState?.lastHvacMode
+  }
+  hvacMode = hvacMode ?: COOLING
   def labels = (0..23).collect { it.toString() }
   def datasets = vents.collect { vent ->
     // Use the Flair room ID if available to match stored hourly rate data
     def roomId = vent.currentValue('room-id') ?: vent.getId()
     def roomName = vent.currentValue('room-name') ?: vent.getLabel()
     def data = (0..23).collect { hr ->
-      getAverageHourlyRate(roomId, hvacMode, hr) ?: 0.0
+      if (hvacMode == 'both') {
+        def cooling = atomicState?.hourlyRates?.get(roomId)?.get(COOLING)?.get(hr) ?: []
+        def heating = atomicState?.hourlyRates?.get(roomId)?.get(HEATING)?.get(hr) ?: []
+        def combined = (cooling + heating).collect { it as BigDecimal }
+        combined ? cleanDecimalForJson(combined.sum() / combined.size()) : 0.0
+      } else {
+        getAverageHourlyRate(roomId, hvacMode, hr) ?: 0.0
+      }
     }
     [label: roomName, data: data]
   }
+  // If all datasets are empty, show a friendly message instead of a blank chart
+  boolean hasData = datasets.any { ds -> ds.data.any { it != 0 } }
+  if (!hasData) {
+    return '<p>No DAB rate history available for the selected mode.</p>'
+  }
+
   def config = [
     type: 'line',
     data: [labels: labels, datasets: datasets],
@@ -3377,8 +3397,11 @@ String buildDabChart() {
       ]
     ]
   ]
-  def encoded = URLEncoder.encode(JsonOutput.toJson(config), 'UTF-8')
-  "<img src='https://quickchart.io/chart?c=${encoded}' style='max-width:100%'>"
+
+  // Encode the chart config using Base64 to avoid URL length/encoding issues
+  def configJson = JsonOutput.toJson(config)
+  def encoded = configJson.bytes.encodeBase64().toString()
+  "<img src='https://quickchart.io/chart?b64=${encoded}' style='max-width:100%'>"
 }
 
 // ------------------------------

--- a/tests/dab-chart-tests.groovy
+++ b/tests/dab-chart-tests.groovy
@@ -54,4 +54,72 @@ class DabChartTests extends Specification {
     def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
     config.data.datasets[0].data[0] == 1.0d
   }
+
+  def "chart falls back to last recorded mode when thermostat mode missing"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.appendHourlyRate('room-1', 'heating', 0, 2.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
+
+  def "chart merges heating and cooling data when both selected"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+
+    def vent = new Expando(
+      hasAttribute: { String attr -> attr == 'percent-open' },
+      getId: { 'device-1' },
+      getLabel: { 'Room1' },
+      currentValue: { String attr ->
+        if (attr == 'room-name') return 'Room1'
+        if (attr == 'room-id') return 'room-1'
+        return null
+      }
+    )
+    script.metaClass.getChildDevices = { -> [vent] }
+    script.metaClass.getThermostat1Mode = { -> null }
+    script.metaClass.getSettings = { [chartHvacMode: 'both'] }
+    script.appendHourlyRate('room-1', 'cooling', 0, 1.0)
+    script.appendHourlyRate('room-1', 'heating', 0, 3.0)
+
+    when:
+    def html = script.buildDabChart()
+
+    then:
+    def encoded = html.split('chart\?c=')[1].split("'")[0]
+    def config = new JsonSlurper().parseText(URLDecoder.decode(encoded, 'UTF-8'))
+    config.data.datasets[0].data[0] == 2.0d
+  }
 }


### PR DESCRIPTION
## Summary
- Encode DAB chart data with Base64 to avoid URL errors and ensure charts render
- Report when no hourly DAB rates exist for the selected HVAC mode
- Preserve HVAC mode fallback when building chart datasets

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching {languageVersion=11} )*


------
https://chatgpt.com/codex/tasks/task_e_68ad0662f8b0832394231ad8babfdbea