### PR TITLE
refactor: use BigDecimal max for rate comparison

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2945,7 +2945,7 @@ def calculateRoomChangeRate(BigDecimal lastStartTemp, BigDecimal currentTemp, Bi
   
   BigDecimal rate = diffTemps / totalMinutes
   BigDecimal pOpen = percentOpen / 100
-  BigDecimal maxRate = Math.max(rate.doubleValue(), currentRate.doubleValue())
+  BigDecimal maxRate = rate.max(currentRate)
   BigDecimal approxRate = maxRate != 0 ? (rate / maxRate) / pOpen : 0
   if (approxRate > MAX_TEMP_CHANGE_RATE) {
     log "Change rate (${roundBigDecimal(approxRate)}) is greater than ${MAX_TEMP_CHANGE_RATE}, therefore it is being excluded", 3


### PR DESCRIPTION
## Summary
- use `rate.max(currentRate)` for BigDecimal comparison in `calculateRoomChangeRate`

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f59176083239e72d8e3006152f6