### PR TITLE
1.0 - handle zero-rate rooms in longest time calc

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2867,7 +2867,7 @@ def calculateLongestMinutesToTarget(rateAndTempPerVentId, String hvacMode, BigDe
           minutesToTarget = maxRunningTime  // Cap at max running time
         }
       } else if (stateVal.rate == 0) {
-        minutesToTarget = 0
+        minutesToTarget = maxRunningTime
         logWarn "'${stateVal.name}' shows no temperature change with vent open"
       }
       if (minutesToTarget > maxRunningTime) {

--- a/tests/time-calculations-tests.groovy
+++ b/tests/time-calculations-tests.groovy
@@ -105,11 +105,11 @@ class TimeCalculationsTest extends Specification {
       'userSettingValues': USER_SETTINGS)
     
     expect:
-    // Zero rate (should return 0)
+    // Zero rate (should return maxRunningTime)
     def rateAndTempPerVentId = [
       'vent1': [rate:0, temp:25, active:true, name: 'Room1']
     ]
-    script.calculateLongestMinutesToTarget(rateAndTempPerVentId, 'cooling', 20, 60, true) == 0
+    script.calculateLongestMinutesToTarget(rateAndTempPerVentId, 'cooling', 20, 60, true) == 60
   }
 
   def "calculateLongestMinutesToTargetTest - Very Slow Rate"() {


### PR DESCRIPTION
## Summary
- treat rooms with zero temperature change rate as taking the max runtime instead of zero minutes
- update zero-rate test expectation

## Testing
- `gradle test` *(fails: 257 tests, 137 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f559de083239b38c60426bb4ccc