### PR TITLE
Handle missing vents during attribute collection

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2778,10 +2778,10 @@ def adjustVentOpeningsToEnsureMinimumAirflowTarget(rateAndTempPerVentId, String 
 def getAttribsPerVentId(ventsByRoomId, String hvacMode) {
   def rateAndTemp = [:]
   ventsByRoomId.each { roomId, ventIds ->
-    ventIds.each { ventId ->
+    for (ventId in ventIds) {
       try {
         def vent = getChildDevice(ventId)
-        if (!vent) { return }
+        if (!vent) { continue }
         def rate = hvacMode == COOLING ? (vent.currentValue('room-cooling-rate') ?: 0) : (vent.currentValue('room-heating-rate') ?: 0)
         rate = rate ?: 0
         def isActive = vent.currentValue('room-active') == 'true'


### PR DESCRIPTION
## Summary
- avoid aborting `getAttribsPerVentId` when a vent is missing
- iterate through vent IDs with `for` loop and skip missing vents

## Testing
- `gradle -Dorg.gradle.java.installations.paths=/usr/lib/jvm/java-11-openjdk-amd64 test` *(fails: 257 tests completed, 137 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f5476cc8323b9caf0610d7cef24