### PR TITLE
fix: continue recording temperatures for missing vents

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2647,10 +2647,12 @@ def recordStartingTemperatures() {
   if (!atomicState.ventsByRoomId) { return }
   log "Recording starting temperatures for all rooms", 2
   atomicState.ventsByRoomId.each { roomId, ventIds ->
-    ventIds.each { ventId ->
+    for (ventId in ventIds) {
       try {
         def vent = getChildDevice(ventId)
-        if (!vent) { return }
+        if (!vent) {
+          continue
+        }
         BigDecimal currentTemp = getRoomTemp(vent)
         sendEvent(vent, [name: 'room-starting-temperature-c', value: currentTemp])
         log "Starting temperature for '${vent.currentValue('room-name')}': ${currentTemp}°C", 2


### PR DESCRIPTION
## Summary
- ensure `recordStartingTemperatures` keeps processing other vents when a vent device is missing

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test' - Cannot find a Java installation on your machine matching: {languageVersion=11, vendor=any vendor}.)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f50b63c8323867c9d31ba538d38