### PR TITLE
feat: exit evaluation after rebalancing

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2481,7 +2481,7 @@ def evaluateRebalancingVents() {
         }
         log "Rebalancing Vents - '${vent.currentValue('room-name')}' is at ${roomTemp}° (target: ${setPoint})", 3
         reBalanceVents()
-        break
+        return // Exit after first rebalancing to avoid multiple adjustments per evaluation
       } catch (err) {
         logError err
       }


### PR DESCRIPTION
## Summary
- stop `evaluateRebalancingVents` after first vent triggers rebalancing

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: There were failing tests. See the report at: file:///workspace/hubitat-flair-vents-beta/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68af2f4fc3c083238e6ab12f865b8c28