### PR TITLE
fix: safeguard DAB activity logging

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -2500,7 +2500,7 @@ def getAverageHourlyRate(String roomId, String hvacMode, Integer hour) {
 
 // Append a new efficiency rate to the rolling 10-day hourly history
 def appendHourlyRate(String roomId, String hvacMode, Integer hour, BigDecimal rate) {
-  def hourlyRates = atomicState.hourlyRates ?: [:]
+  def hourlyRates = atomicState?.hourlyRates ?: [:]
   def roomRates = hourlyRates[roomId] ?: [:]
   def modeRates = roomRates[hvacMode] ?: [:]
   def list = modeRates[hour] ?: []
@@ -2509,16 +2509,16 @@ def appendHourlyRate(String roomId, String hvacMode, Integer hour, BigDecimal ra
   modeRates[hour] = list
   roomRates[hvacMode] = modeRates
   hourlyRates[roomId] = roomRates
-  atomicState.hourlyRates = hourlyRates
-  atomicState.lastHvacMode = hvacMode
+  atomicState?.hourlyRates = hourlyRates
+  atomicState?.lastHvacMode = hvacMode
 }
 
 def appendDabActivityLog(String message) {
-  def list = atomicState.dabActivityLog ?: []
+  def list = atomicState?.dabActivityLog ?: []
   String ts = new Date().format('yyyy-MM-dd HH:mm:ss', location?.timeZone ?: TimeZone.getTimeZone('UTC'))
   list << "${ts} - ${message}"
   if (list.size() > 100) { list = list[-100..-1] }
-  atomicState.dabActivityLog = list
+  atomicState?.dabActivityLog = list
 }
 
 private boolean isFanActive(String opState = null) {
@@ -3352,7 +3352,7 @@ def efficiencyDataPage() {
 def dabActivityLogPage() {
   dynamicPage(name: 'dabActivityLogPage', title: '📘 DAB Activity Log', install: false, uninstall: false) {
     section {
-      def entries = atomicState.dabActivityLog ?: []
+      def entries = atomicState?.dabActivityLog ?: []
       if (entries) {
         entries.reverse().each { paragraph "<code>${it}</code>" }
       } else {
@@ -3379,8 +3379,8 @@ def dabChartPage() {
 }
 
 String buildDabChart() {
-  def vents = getChildDevices().findAll { it.hasAttribute('percent-open') }
-  if (!vents || vents.size() == 0) {
+  def vents = getChildDevices()?.findAll { it.hasAttribute('percent-open') } ?: []
+  if (vents.isEmpty()) {
     return '<p>No vent data available.</p>'
   }
   String hvacMode = settings?.chartHvacMode ?: getThermostat1Mode() ?: atomicState?.lastHvacMode


### PR DESCRIPTION
## Summary
- avoid null state errors in DAB logging and history functions
- prevent NPE when building DAB chart without devices

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test --tests "bot.flair.VentOpeningCalculationsTest"`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: 28 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8f18d6d0832395c6c2fe6e9a53a0