### PR TITLE
1 v1 Add table view for hourly DAB rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.238] - 2025-08-26
+
+### Added
+- Table page displaying hourly Dynamic Airflow Balancing (DAB) rates for each room
+
 ## [0.237] - 2025-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Harness the power of Dynamic Airflow Balancing to refine air distribution throug
 - **Rate of temperature change calculation** in each room for precise vent adjustment.
 - **Reduced adjustments** mean less wear on vent motors and quieter operation.
 - **Minimum airflow compliance** to prevent HVAC issues from insufficient airflow, particularly useful when integrating Flair Smart Vents with traditional vents.
+- **Hourly DAB insights** via built-in chart and table showing per-room calculations for each hour of the day.
 
 ### Enhanced Vent Control and Combined Airflow Management
 This integration doesn't just enable remote control over each Flair vent; it smartly manages airflow to ensure your HVAC system operates efficiently without damage. Key features include:


### PR DESCRIPTION
## Summary
- add hourly DAB rates table page to view per-room calculations by hour
- document new hourly DAB insights feature
- record addition in changelog

## Testing
- `gradle test` *(fails: InvalidAlgorithmParameterException - trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68ae287344b48323bbb32367772a4fb1