### PR TITLE
Initialize DAB history and harden rate tracking

### DIFF
--- a/tests/dab-chart-tests.groovy
+++ b/tests/dab-chart-tests.groovy
@@ -24,6 +24,7 @@ class DabChartTests extends Specification {
     final log = new CapturingLog()
     AppExecutor executorApi = Mock {
       _ * getState() >> [:]
+      _ * getAtomicState() >> [:]
       _ * getLog() >> log
     }
     def sandbox = new HubitatAppSandbox(APP_FILE)
@@ -60,6 +61,7 @@ class DabChartTests extends Specification {
     final log = new CapturingLog()
     AppExecutor executorApi = Mock {
       _ * getState() >> [:]
+      _ * getAtomicState() >> [:]
       _ * getLog() >> log
     }
     def sandbox = new HubitatAppSandbox(APP_FILE)
@@ -93,6 +95,7 @@ class DabChartTests extends Specification {
     final log = new CapturingLog()
     AppExecutor executorApi = Mock {
       _ * getState() >> [:]
+      _ * getAtomicState() >> [:]
       _ * getLog() >> log
     }
     def sandbox = new HubitatAppSandbox(APP_FILE)

--- a/tests/hourly-dab-tests.groovy
+++ b/tests/hourly-dab-tests.groovy
@@ -22,6 +22,7 @@ class HourlyDabTests extends Specification {
     final log = new CapturingLog()
     AppExecutor executorApi = Mock {
       _ * getState() >> [:]
+      _ * getAtomicState() >> [:]
       _ * getLog() >> log
     }
     def sandbox = new HubitatAppSandbox(APP_FILE)
@@ -31,7 +32,7 @@ class HourlyDabTests extends Specification {
     (1..11).each { script.appendHourlyRate('room1', 'cooling', 0, it) }
 
     then:
-    script.atomicState.hourlyRates.room1.cooling[0].size() == 10
+    script.atomicState.dabHistory.hourlyRates.room1.cooling[0].size() == 10
     script.getAverageHourlyRate('room1', 'cooling', 0) == 6.5
   }
 }


### PR DESCRIPTION
## Summary
- initialize `atomicState.dabHistory` during setup
- guard history structures and warn when inserts fail
- adapt history tests to mock atomic state

## Testing
- `gradle test` *(fails: 257 tests completed, 27 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af48a3e1908323a90c57be630883ed