### PR TITLE
1.0 feat: diagnostics page for troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ Control and automation are at your fingertips. Each Flair vent appears as an ind
 - Set the **vent opening level** with `setLevel` (0 for closed, 100 for fully open).
 - Manage **room activity** using the `setRoomActive` command to strategically manage airflow based on room usage.
 
+## Diagnostics & Debugging
+
+Access **View Diagnostics** from the app's Debug Options to troubleshoot your setup.
+
+- **Cached Device Data** – shows current vent cache contents. Use **Reset Cache** if data appears stale.
+- **Recent Error Logs** – lists the last 20 errors captured when debug mode is enabled.
+- **Health Check** – validates API connectivity and counts discovered vents. Press **Run Health Check** for an updated status.
+- **Actions** – buttons to re-authenticate or re-sync vents when needed.
+
+### Enable Debug Mode
+
+In the app's settings, choose a **debug level** greater than `0` under Debug Options. Higher levels output more detailed logs and populate the diagnostics page.
+
 ## Development & Testing
 
 ### Prerequisites

--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -149,6 +149,7 @@ preferences {
   page(name: 'dabRatesTablePage')
   page(name: 'dabActivityLogPage')
   page(name: 'dabProgressPage')
+  page(name: 'diagnosticsPage')
 }
 
 def mainPage() {
@@ -283,8 +284,80 @@ def mainPage() {
     section('Debug Options') {
       input name: 'debugLevel', type: 'enum', title: 'Choose debug level', defaultValue: 0,
             options: [0: 'None', 1: 'Level 1 (All)', 2: 'Level 2', 3: 'Level 3'], submitOnChange: true
+      href name: 'diagnosticsLink', title: 'View Diagnostics',
+           description: 'Troubleshoot vent data and logs', page: 'diagnosticsPage'
     }
   }
+}
+
+def diagnosticsPage() {
+  dynamicPage(name: 'diagnosticsPage', title: 'Diagnostics') {
+    section('Cached Device Data') {
+      def cache = state."instanceCache_${getInstanceId()}_deviceCache"
+      if (cache) {
+        cache.each { id, data ->
+          paragraph "<b>${id}</b>: ${data}"
+        }
+      } else {
+        paragraph 'No cached device data.'
+      }
+      input name: 'resetCache', type: 'button', title: 'Reset Cache'
+    }
+    section('Recent Error Logs') {
+      def logs = state.recentErrors ?: []
+      if (logs) {
+        logs.reverse().each { paragraph it }
+      } else {
+        paragraph 'No recent errors.'
+      }
+    }
+    section('Health Check') {
+      if (state.healthCheckResults) {
+        paragraph state.healthCheckResults.results.join('<br/>')
+        paragraph "<small>Last run: ${state.healthCheckResults.timestamp}</small>"
+      } else {
+        paragraph 'No health check run yet.'
+      }
+      input name: 'runHealthCheck', type: 'button', title: 'Run Health Check'
+    }
+    section('Actions') {
+      input name: 'reauthenticate', type: 'button', title: 'Re-Authenticate'
+      input name: 'resyncVents', type: 'button', title: 'Re-Sync Vents'
+    }
+  }
+}
+
+def performHealthCheck() {
+  def results = []
+  results << (state.flairAccessToken ? 'Auth token present' : 'Auth token missing')
+  try {
+    httpGet([
+      uri: "${BASE_URL}/api/structures",
+      headers: [Authorization: "Bearer ${state.flairAccessToken}"],
+      timeout: HTTP_TIMEOUT_SECS,
+      contentType: CONTENT_TYPE
+    ]) { resp ->
+      results << "API reachable: HTTP ${resp.status}"
+    }
+  } catch (e) {
+    results << "API error: ${e.message}"
+  }
+  def ventCount = getChildDevices().findAll { it.hasAttribute('percent-open') }.size()
+  results << "Vents discovered: ${ventCount}"
+  state.healthCheckResults = [
+    timestamp: new Date().format('yyyy-MM-dd HH:mm:ss', location.timeZone ?: TimeZone.getTimeZone('UTC')),
+    results: results
+  ]
+}
+
+def resetCaches() {
+  def instanceId = getInstanceId()
+  def cacheKey = "instanceCache_${instanceId}"
+  ['roomCache', 'roomCacheTimestamps', 'deviceCache', 'deviceCacheTimestamps',
+   'pendingRoomRequests', 'pendingDeviceRequests', 'initialized'].each { suffix ->
+    state.remove("${cacheKey}_${suffix}")
+  }
+  log 'Instance caches cleared', 2
 }
 
 // ------------------------------
@@ -986,6 +1059,12 @@ private logError(String msg) {
   if (settingsLevel > 0) {
     log.error msg
   }
+  def ts = new Date().format('yyyy-MM-dd HH:mm:ss', location.timeZone ?: TimeZone.getTimeZone('UTC'))
+  def errors = (state.recentErrors ?: []) + ["${ts} - ${msg}"]
+  if (errors.size() > 20) {
+    errors = errors[-20..-1]
+  }
+  state.recentErrors = errors
 }
 
 // Wrapper for log.warn that respects debugLevel setting
@@ -1286,6 +1365,18 @@ def appButtonHandler(String btn) {
       runEvery1Hour(login)
       break
     case 'discoverDevices':
+      discover()
+      break
+    case 'runHealthCheck':
+      performHealthCheck()
+      break
+    case 'reauthenticate':
+      autoReauthenticate()
+      break
+    case 'resetCache':
+      resetCaches()
+      break
+    case 'resyncVents':
       discover()
       break
     case 'exportEfficiencyData':


### PR DESCRIPTION
## Summary
- add diagnostics page to view cached data, health checks, and error logs
- expose diagnostics link in app preferences
- document diagnostics and debug mode in README

## Testing
- `gradle test` *(fails: Could not resolve dependencies; trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68af4d2ab3c48323b2e2eb7cc1972a8c