### PR TITLE
1.0 Add exponential backoff and API circuit breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.239] - 2025-08-27
+
+### Added
+- Exponential backoff and per-URI circuit breaker for API requests with automatic re-authentication on repeated failures
+
 ## [0.238] - 2025-08-26
 
 ### Added

--- a/tests/request-throttling-comprehensive-tests.groovy
+++ b/tests/request-throttling-comprehensive-tests.groovy
@@ -415,6 +415,66 @@ class RequestThrottlingComprehensiveTest extends Specification {
     script.atomicState.activeRequests == 2
   }
 
+  def "getDataAsync triggers circuit breaker after consecutive failures"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock(AppExecutor) {
+      _ * getState() >> [flairAccessToken: 'test-token']
+      _ * getLog() >> log
+      _ * getSetting('debugLevel') >> 1
+      _ * getAtomicState() >> [activeRequests: 0]
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS,
+      'userSettingValues': ['debugLevel': 1])
+    script.state = [flairAccessToken: 'test-token']
+    script.atomicState = [activeRequests: 0, failureCounts: [:]]
+    script.metaClass.canMakeRequest = { -> false }
+    boolean resetCalled = false
+    script.metaClass.resetApiConnection = { -> resetCalled = true }
+    def uri = 'test-uri'
+
+    when:
+    script.API_FAILURE_THRESHOLD.times {
+      script.getDataAsync(uri, 'testCallback', null, script.MAX_API_RETRY_ATTEMPTS)
+    }
+
+    then:
+    resetCalled
+    script.atomicState.failureCounts == [:]
+    log.records.contains(new Tuple(Level.warn, "API circuit breaker activated for ${uri} after ${script.API_FAILURE_THRESHOLD} failures"))
+  }
+
+  def "patchDataAsync triggers circuit breaker after consecutive failures"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock(AppExecutor) {
+      _ * getState() >> [flairAccessToken: 'test-token']
+      _ * getLog() >> log
+      _ * getSetting('debugLevel') >> 1
+      _ * getAtomicState() >> [activeRequests: 0]
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS,
+      'userSettingValues': ['debugLevel': 1])
+    script.state = [flairAccessToken: 'test-token']
+    script.atomicState = [activeRequests: 0, failureCounts: [:]]
+    script.metaClass.canMakeRequest = { -> false }
+    boolean resetCalled = false
+    script.metaClass.resetApiConnection = { -> resetCalled = true }
+    def uri = 'test-uri'
+
+    when:
+    script.API_FAILURE_THRESHOLD.times {
+      script.patchDataAsync(uri, 'testCallback', [test: 'body'], null, script.MAX_API_RETRY_ATTEMPTS)
+    }
+
+    then:
+    resetCalled
+    script.atomicState.failureCounts == [:]
+    log.records.contains(new Tuple(Level.warn, "API circuit breaker activated for ${uri} after ${script.API_FAILURE_THRESHOLD} failures"))
+  }
+
   def "throttling system maintains request counts accurately under concurrent load simulation"() {
     setup:
     AppExecutor executorApi = Mock(AppExecutor) {


### PR DESCRIPTION
## Summary
- use exponential backoff for API retries and track per-URI failures
- reset API connection and warn users when failures exceed threshold

## Testing
- `gradle test` *(fails: Cannot find a Java installation matching {languageVersion=11})*

------
https://chatgpt.com/codex/tasks/task_e_68af4d39664c8323af48013bac7463c7