### PR TITLE
1.0: track DAB history with timestamps

### DIFF
--- a/tests/hourly-dab-tests.groovy
+++ b/tests/hourly-dab-tests.groovy
@@ -30,14 +30,14 @@ class HourlyDabTests extends Specification {
     script.settings = [dabHistoryRetentionDays: 10]
 
     and: 'prepopulate history with an old entry'
-    def oldDate = (new Date() - 11).format('yyyy-MM-dd', TimeZone.getTimeZone('UTC'))
-    script.atomicState = [dabHistory: [room1: [cooling: [[date: oldDate, hour: 0, rate: 1.0]]]]]
+    def oldTs = (new Date() - 11).getTime()
+    script.atomicState = [dabHistoryStartTimestamp: oldTs, dabHistory: [[oldTs, 'room1', 'cooling', 0, 1.0]]]
 
     when: 'appending a new rate'
     script.appendHourlyRate('room1', 'cooling', 0, 2.0)
 
     then: 'old entry is purged and average uses remaining values'
-    script.atomicState.dabHistory.room1.cooling.size() == 1
+    script.atomicState.dabHistory.size() == 1
     script.getAverageHourlyRate('room1', 'cooling', 0) == 2.0
   }
 }


### PR DESCRIPTION
## Summary
- record DAB entries with timestamps and room context
- prune history by retention window and track start timestamp
- log DAB activity with tracking start reference

## Testing
- `gradle test` *(fails: TimeCalculationsTest > calculateLongestMinutesToTargetTest - Zero Rate Scenarios FAILED, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68af6566db7c8323a1dce15b5e64b7f6