### PR TITLE
1.0: preserve DAB history during export/import

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -3123,6 +3123,12 @@ def handleImportEfficiencyData() {
       if (result.globalUpdated) {
         statusMsg += " and global efficiency rates"
       }
+      if (result.historyRestored) {
+        statusMsg += ", restored history"
+      }
+      if (result.activityLogRestored) {
+        statusMsg += ", restored activity log"
+      }
       if (result.roomsSkipped > 0) {
         statusMsg += ". Skipped ${result.roomsSkipped} rooms (not found)"
       }
@@ -3166,7 +3172,9 @@ def exportEfficiencyData() {
       maxCoolingRate: cleanDecimalForJson(atomicState.maxCoolingRate),
       maxHeatingRate: cleanDecimalForJson(atomicState.maxHeatingRate)
     ],
-    roomEfficiencies: []
+    roomEfficiencies: [],
+    dabHistory: atomicState?.dabHistory ?: [:],
+    dabActivityLog: atomicState?.dabActivityLog ?: []
   ]
   
   // Only collect from vents (devices with percent-open attribute)
@@ -3226,7 +3234,7 @@ def exportDabHistory(String format = 'json') {
 def generateEfficiencyJSON(data) {
   def exportData = [
     exportMetadata: [
-      version: '0.23',
+      version: '0.24',
       exportDate: new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'"),
       structureId: settings.structureId ?: 'Unknown'
     ],
@@ -3250,6 +3258,8 @@ def importEfficiencyData(jsonContent) {
       globalUpdated: results.globalUpdated,
       roomsUpdated: results.roomsUpdated,
       roomsSkipped: results.roomsSkipped,
+      historyRestored: results.historyRestored,
+      activityLogRestored: results.activityLogRestored,
       errors: results.errors
     ]
   } catch (Exception e) {
@@ -3262,6 +3272,8 @@ def validateImportData(jsonData) {
   if (!jsonData.exportMetadata || !jsonData.efficiencyData) return false
   if (!jsonData.efficiencyData.globalRates) return false
   if (!jsonData.efficiencyData.roomEfficiencies) return false
+  if (jsonData.efficiencyData.dabHistory && !(jsonData.efficiencyData.dabHistory instanceof Map)) return false
+  if (jsonData.efficiencyData.dabActivityLog && !(jsonData.efficiencyData.dabActivityLog instanceof List)) return false
   
   // Validate global rates
   def globalRates = jsonData.efficiencyData.globalRates
@@ -3285,7 +3297,9 @@ def applyImportedEfficiencies(efficiencyData) {
     globalUpdated: false,
     roomsUpdated: 0,
     roomsSkipped: 0,
-    errors: []
+    errors: [],
+    historyRestored: false,
+    activityLogRestored: false
   ]
   
   // Update global rates
@@ -3311,7 +3325,19 @@ def applyImportedEfficiencies(efficiencyData) {
       log "Skipped room '${roomData.roomName}' - no matching device found", 2
     }
   }
-  
+
+  if (efficiencyData.dabHistory) {
+    atomicState.dabHistory = efficiencyData.dabHistory
+    results.historyRestored = true
+    log "Restored DAB history (${efficiencyData.dabHistory.size()} rooms)", 2
+  }
+
+  if (efficiencyData.dabActivityLog) {
+    atomicState.dabActivityLog = efficiencyData.dabActivityLog
+    results.activityLogRestored = true
+    log "Restored DAB activity log (${efficiencyData.dabActivityLog.size()} entries)", 2
+  }
+
   return results
 }
 

--- a/tests/efficiency-import-edge-cases-tests.groovy
+++ b/tests/efficiency-import-edge-cases-tests.groovy
@@ -186,7 +186,7 @@ class EfficiencyImportEdgeCasesTest extends Specification {
     def "test validation with missing required fields"() {
         given: "JSON data missing required structure"
         def invalidData = [
-            exportMetadata: [version: '0.22'],
+            exportMetadata: [version: '0.24'],
             efficiencyData: [
                 globalRates: [:], // Missing required rates
                 roomEfficiencies: [
@@ -321,7 +321,7 @@ class EfficiencyImportEdgeCasesTest extends Specification {
     def "test import with missing global rates section"() {
         given: "JSON data without global rates"
         def jsonData = [
-            exportMetadata: [version: '0.22', exportDate: '2025-06-26T15:00:00Z'],
+            exportMetadata: [version: '0.24', exportDate: '2025-06-26T15:00:00Z'],
             efficiencyData: [
                 roomEfficiencies: [
                     [roomId: 'room-123', roomName: 'Living Room', ventId: 'device-1', coolingRate: 0.6, heatingRate: 0.8]
@@ -373,7 +373,7 @@ class EfficiencyImportEdgeCasesTest extends Specification {
     private createValidBackupJson(roomData) {
         return [
             exportMetadata: [
-                version: '0.22',
+                version: '0.24',
                 exportDate: '2025-06-26T15:00:00Z',
                 structureId: 'test-structure'
             ],


### PR DESCRIPTION
## Summary
- include DAB history and activity log in exported JSON
- restore DAB history and activity log on import with status indicators

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test'. Could not resolve all dependencies for configuration ':testRuntimeClasspath'.)*

------
https://chatgpt.com/codex/tasks/task_e_68af656451508323b3ecbe145443c650