### PR TITLE
1.0 - archive DAB history with rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ memory-bank
 .idea/
 .vscode/
 .hubitat/
+data/*.json

--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -20,6 +20,7 @@
 
 import groovy.transform.Field
 import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
 import java.net.URLEncoder
 
 // ------------------------------
@@ -34,6 +35,9 @@ import java.net.URLEncoder
 @Field static final Long DEVICE_CACHE_DURATION_MS = 30000 // 30 second cache duration for device readings
 @Field static final Integer MAX_CACHE_SIZE = 50 // Maximum cache entries per instance
 @Field static final Integer DEFAULT_HISTORY_RETENTION_DAYS = 10 // Default days to retain DAB history
+@Field static final String DAB_HISTORY_FILE = 'data/dab-history.json'
+@Field static final Long DAB_HISTORY_MAX_FILE_SIZE = 1024 * 1000  // 1 MB
+@Field static final Integer DAB_HISTORY_MAX_ARCHIVES = 5
 
 // Content-Type header for API requests.
 @Field static final String CONTENT_TYPE = 'application/json'
@@ -2564,6 +2568,7 @@ def appendHourlyRate(String roomId, String hvacMode, Integer hour, BigDecimal ra
   history[roomId] = roomHistory
   atomicState?.dabHistory = history
   atomicState?.lastHvacMode = hvacMode
+  archiveDabHistoryEntry([type: 'hourlyRate', roomId: roomId, hvacMode: hvacMode, hour: hour, rate: rate, date: dateStr])
 }
 
 def appendDabActivityLog(String message) {
@@ -2572,6 +2577,61 @@ def appendDabActivityLog(String message) {
   list << "${ts} - ${message}"
   if (list.size() > 100) { list = list[-100..-1] }
   atomicState?.dabActivityLog = list
+  archiveDabHistoryEntry([type: 'activity', message: message, timestamp: ts])
+}
+
+private void archiveDabHistoryEntry(Map entry) {
+  try {
+    File file = new File(DAB_HISTORY_FILE)
+    File dir = file.parentFile
+    if (!dir.exists()) { dir.mkdirs() }
+    List history = []
+    if (file.exists()) {
+      try {
+        history = new JsonSlurper().parseText(file.text) as List
+      } catch (ignored) {
+        history = []
+      }
+    } else {
+      file.text = '[]'
+    }
+    history << entry
+    file.text = JsonOutput.prettyPrint(JsonOutput.toJson(history))
+    rotateDabHistoryFileIfNeeded(file)
+  } catch (Exception e) {
+    logWarn "Failed to archive DAB history: ${e.message}"
+  }
+}
+
+private void rotateDabHistoryFileIfNeeded(File file) {
+  if (file.length() > DAB_HISTORY_MAX_FILE_SIZE) {
+    String ts = new Date().format('yyyyMMddHHmmss', location?.timeZone ?: TimeZone.getTimeZone('UTC'))
+    File dir = file.parentFile
+    File archive = new File(dir, "dab-history-${ts}.json")
+    file.renameTo(archive)
+    file.text = '[]'
+    def archives = dir.listFiles()?.findAll { it.name.startsWith('dab-history-') && it.name.endsWith('.json') }?.sort { it.lastModified() } ?: []
+    while (archives.size() > DAB_HISTORY_MAX_ARCHIVES) {
+      archives[0].delete()
+      archives = archives.drop(1)
+    }
+  }
+}
+
+def readDabHistoryArchive() {
+  File file = new File(DAB_HISTORY_FILE)
+  File dir = file.parentFile
+  if (!dir.exists()) { return [] }
+  def slurper = new JsonSlurper()
+  def files = dir.listFiles()?.findAll { it.name.startsWith('dab-history') && it.name.endsWith('.json') }?.sort { it.name }
+  def data = []
+  files.each { f ->
+    try {
+      def content = slurper.parseText(f.text)
+      if (content instanceof List) { data.addAll(content) }
+    } catch (ignored) { }
+  }
+  data
 }
 
 private boolean isFanActive(String opState = null) {

--- a/tests/dab-history-archive-tests.groovy
+++ b/tests/dab-history-archive-tests.groovy
@@ -1,0 +1,42 @@
+package bot.flair
+
+import me.biocomp.hubitat_ci.util.CapturingLog
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
+import me.biocomp.hubitat_ci.app.HubitatAppSandbox
+import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Specification
+
+class DabHistoryArchiveTests extends Specification {
+
+  private static final File APP_FILE = new File('src/hubitat-flair-vents-app.groovy')
+  private static final List VALIDATION_FLAGS = [
+    Flags.DontValidateMetadata,
+    Flags.DontValidatePreferences,
+    Flags.DontValidateDefinition,
+    Flags.DontRestrictGroovy,
+    Flags.DontRequireParseMethodInDevice
+  ]
+
+  def setup() {
+    new File('data').deleteDir()
+  }
+
+  def "activity logs are archived and retrievable"() {
+    setup:
+    final log = new CapturingLog()
+    AppExecutor executorApi = Mock {
+      _ * getState() >> [:]
+      _ * getLog() >> log
+    }
+    def sandbox = new HubitatAppSandbox(APP_FILE)
+    def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
+    script.location = [timeZone: TimeZone.getTimeZone('UTC')]
+
+    when:
+    script.appendDabActivityLog('testing archive')
+
+    then:
+    def history = script.readDabHistoryArchive()
+    history.any { it.type == 'activity' && it.message == 'testing archive' }
+  }
+}


### PR DESCRIPTION
## Summary
- persist DAB hourly rates and activity logs to `data/dab-history.json`
- rotate archived history files by size and keep a limited number of backups
- expose `readDabHistoryArchive` helper and test basic archive retrieval

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: Could not resolve dependencies; SSLInitializationException)*

------
https://chatgpt.com/codex/tasks/task_e_68af6562b23483239423f67521263605