### PR TITLE
1.0 Track DAB rate calculation history

### DIFF
--- a/tests/hourly-dab-tests.groovy
+++ b/tests/hourly-dab-tests.groovy
@@ -31,13 +31,13 @@ class HourlyDabTests extends Specification {
 
     and: 'prepopulate history with an old entry'
     def oldDate = (new Date() - 11).format('yyyy-MM-dd', TimeZone.getTimeZone('UTC'))
-    script.atomicState = [dabHistory: [room1: [cooling: [[date: oldDate, hour: 0, rate: 1.0]]]]]
+    script.atomicState = [hourlyRates: [room1: [cooling: [[date: oldDate, hour: 0, rate: 1.0]]]]]
 
     when: 'appending a new rate'
     script.appendHourlyRate('room1', 'cooling', 0, 2.0)
 
     then: 'old entry is purged and average uses remaining values'
-    script.atomicState.dabHistory.room1.cooling.size() == 1
+    script.atomicState.hourlyRates.room1.cooling.size() == 1
     script.getAverageHourlyRate('room1', 'cooling', 0) == 2.0
   }
 }


### PR DESCRIPTION
## Summary
- log detailed DAB rate events per room and hour
- initialize DAB history on install or update

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 gradle test` *(fails: trustAnchors parameter must be non-empty)*


------
https://chatgpt.com/codex/tasks/task_e_68af656069a8832383374fa801a30a70