### PR TITLE
feat: add cooling cycle counter and DAB task plan

### DIFF
--- a/DAB_TASKS.md
+++ b/DAB_TASKS.md
@@ -1,0 +1,37 @@
+# DAB Improvement Tasks
+
+## Priority 1 - High impact, low risk
+- 1 v1 Cooling cycle counter with reset button
+  - Complexity: low
+  - Risk: low
+- 2 v1 Surface DAB command errors in UI with actionable messages
+  - Complexity: medium
+  - Risk: medium
+- 3 v1 Prompt user to resolve missing data (sensors, network) without code changes
+  - Complexity: medium
+  - Risk: low
+- 4 v1 Add rate-limited diagnostic logging and export option
+  - Complexity: medium
+  - Risk: medium
+
+## Priority 2 - Structural improvements
+- 5 v1 Paginate heavy DAB reports and remove overly complex charts
+  - Complexity: medium
+  - Risk: medium
+- 6 v1 Move one-time setup items to dedicated configuration page(s)
+  - Complexity: low
+  - Risk: low
+- 7 v1 Create landing page with DAB & system health indicators and command confirmation icons
+  - Complexity: high
+  - Risk: medium-high
+
+## Priority 3 - Advanced features
+- 8 v1 Room tiles on landing page showing current temperature and settings
+  - Complexity: high
+  - Risk: high
+- 9 v1 Implement room weighting algorithm based on setpoints with fallback to manual weights
+  - Complexity: high
+  - Risk: high
+- 10 v1 Advanced debugging toggles with category filters to avoid log noise
+  - Complexity: medium
+  - Risk: medium


### PR DESCRIPTION
## Summary
- add a cooling cycle counter with reset button to HVAC status
- count cycles when HVAC starts cooling
- document prioritized DAB improvement tasks

## Testing
- `gradle clean test` *(fails: 270 tests completed, 178 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b626215ea08323b34fd0a4bd162e59