### PR TITLE
refactor: remove duplicate cache init

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -1505,16 +1505,13 @@ private getInstanceId() {
   return "test-${now()}"
 }
 
-// Initialize instance-level cache variables
-private initializeInstanceCaches() {
-  // Ensure throttling counters/maps exist for CI/tests and runtime
-  try { if (atomicState.activeRequests == null) { atomicState.activeRequests = 0 } } catch (ignore) { }
-  try { if (state.circuitOpenUntil == null) { state.circuitOpenUntil = [:] } } catch (ignore) { }
-// Ensure throttling counters/maps exist for CI/tests and runtime
-  try { if (atomicState.activeRequests == null) { atomicState.activeRequests = 0 } } catch (ignore) { }
-  try { if (state.circuitOpenUntil == null) { state.circuitOpenUntil = [:] } } catch (ignore) { }
-  def instanceId = getInstanceId()
-  def cacheKey = "instanceCache_${instanceId}"
+  // Initialize instance-level cache variables
+  private initializeInstanceCaches() {
+    // Ensure throttling counters/maps exist for CI/tests and runtime
+    try { if (atomicState.activeRequests == null) { atomicState.activeRequests = 0 } } catch (ignore) { }
+    try { if (state.circuitOpenUntil == null) { state.circuitOpenUntil = [:] } } catch (ignore) { }
+    def instanceId = getInstanceId()
+    def cacheKey = "instanceCache_${instanceId}"
   
   if (!state."${cacheKey}_initialized") {
     state."${cacheKey}_roomCache" = [:]


### PR DESCRIPTION
## Summary
- remove repeated initialization of atomic state caches in `initializeInstanceCaches`

## Testing
- `gradle test` *(fails: Could not resolve dependencies due to SSLInitializationException)*

------
https://chatgpt.com/codex/tasks/task_e_68b842cd9a0483238f1bc16d0f289314