### PR TITLE
1.0: use getTypeName for quick control vent filter

### DIFF
--- a/src/hubitat-flair-vents-app.groovy
+++ b/src/hubitat-flair-vents-app.groovy
@@ -6545,7 +6545,7 @@ def quickControlsPage() {
   dynamicPage(name: 'quickControlsPage', title: '\u26A1 Quick Controls', install: false, uninstall: false) {
     section('Per-Room Status & Controls') {
       // Identify vent devices by driver type to avoid missing vents when attributes are absent
-      def vents = getChildDevices()?.findAll { (it.typeName ?: '') == 'Flair vents' } ?: []
+      def vents = getChildDevices()?.findAll { (it.getTypeName() ?: '') == 'Flair vents' } ?: []
       // Append vents that expose percent-open but lack type information
       vents += getChildDevices()?.findAll { it.hasAttribute('percent-open') } ?: []
       // De-duplicate vents by device ID before building the room map
@@ -6592,7 +6592,7 @@ def quickControlsPage() {
       input name: 'applyQuickControlsNow', type: 'button', title: 'Apply All Changes', submitOnChange: true
     }
     section('Active Rooms Now') {
-      def vents = getChildDevices()?.findAll { (it.typeName ?: '') == 'Flair vents' } ?: []
+      def vents = getChildDevices()?.findAll { (it.getTypeName() ?: '') == 'Flair vents' } ?: []
       vents += getChildDevices()?.findAll { it.hasAttribute('percent-open') } ?: []
       def uniqueVents = [:]
       vents.each { v -> uniqueVents[v.getId()] = v }

--- a/tests/quick-controls-tests.groovy
+++ b/tests/quick-controls-tests.groovy
@@ -16,14 +16,16 @@ class QuickControlsTests extends Specification {
     Flags.AllowReadingNonInputSettings
   ]
 
-  def "quick controls include vents with and without getTypeName"() {
+  def "quick controls include vents matched by driver or attribute"() {
     setup:
     AppExecutor executorApi = Mock { _ * getState() >> [:] }
     def sandbox = new HubitatAppSandbox(APP_FILE)
     def script = sandbox.run('api': executorApi, 'validationFlags': VALIDATION_FLAGS)
     script.atomicState = [:]
+    script.metaClass.getAtomicState = { -> script.@atomicState }
+    script.metaClass.setAtomicState = { val -> script.@atomicState = val }
 
-    def ventWithMethod = new Expando(
+    def ventMatchedByDriver = new Expando(
       getTypeName: { 'Flair vents' },
       getDeviceNetworkId: { 'vent1' },
       getLabel: { 'Vent 1' },
@@ -37,8 +39,8 @@ class QuickControlsTests extends Specification {
       }
     )
 
-    def ventWithoutMethod = new Expando(
-      typeName: 'Flair vents',
+    def ventMatchedByAttribute = new Expando(
+      getTypeName: { 'Generic Vent' },
       getDeviceNetworkId: { 'vent2' },
       getLabel: { 'Vent 2' },
       currentValue: { attr ->
@@ -51,7 +53,7 @@ class QuickControlsTests extends Specification {
       }
     )
 
-    script.metaClass.getChildDevices = { -> [ventWithMethod, ventWithoutMethod] }
+    script.metaClass.getChildDevices = { -> [ventMatchedByDriver, ventMatchedByAttribute] }
 
     when:
     def page = script.quickControlsPage()


### PR DESCRIPTION
## Summary
- detect Flair vents in quick controls via `getTypeName()`
- update quick control tests to account for driver-type and attribute-based detection

## Testing
- `gradle test` *(fails: Could not determine dependencies of task ':test' ... but after installing JDK 11 the test run completes with failing tests)*
- `gradle test --tests "bot.flair.QuickControlsTests"` *(fails: Cannot set property 'qcDeviceMap' on null object)*

------
https://chatgpt.com/codex/tasks/task_e_68b841bdd1048323bb069058ec83516c